### PR TITLE
feat: replace mock API with sqlite server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,18 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.8.0"
+    "react-router-dom": "^7.8.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "sqlite": "^5.1.6",
+    "sqlite3": "^5.1.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,346 @@
+import express from 'express';
+import cors from 'cors';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+let db;
+
+async function initDb() {
+  db = await open({
+    filename: './data.sqlite',
+    driver: sqlite3.Database
+  });
+
+  await db.exec(`CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      description TEXT,
+      createdAt TEXT,
+      updatedAt TEXT
+    );
+    CREATE TABLE IF NOT EXISTS screens (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      domain TEXT,
+      urlPath TEXT,
+      projectId TEXT,
+      description TEXT,
+      createdAt TEXT,
+      updatedAt TEXT
+    );
+    CREATE TABLE IF NOT EXISTS tags (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      projectId TEXT,
+      createdAt TEXT
+    );
+    CREATE TABLE IF NOT EXISTS testScripts (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      projectId TEXT,
+      screenId TEXT,
+      tagId TEXT,
+      version INTEGER,
+      fileName TEXT,
+      fileContent TEXT,
+      createdAt TEXT,
+      updatedAt TEXT
+    );
+    CREATE TABLE IF NOT EXISTS testResults (
+      id TEXT PRIMARY KEY,
+      testScriptId TEXT,
+      status TEXT,
+      startTime TEXT,
+      endTime TEXT,
+      errorMessage TEXT,
+      screenshots TEXT,
+      consoleErrors TEXT,
+      steps TEXT,
+      createdAt TEXT
+    );`);
+}
+
+function generateId() {
+  return Date.now().toString(36) + Math.random().toString(36).substr(2);
+}
+
+// Projects
+app.get('/api/projects', async (_req, res) => {
+  const rows = await db.all('SELECT * FROM projects');
+  res.json(rows);
+});
+
+app.post('/api/projects', async (req, res) => {
+  const id = generateId();
+  const createdAt = new Date().toISOString();
+  const updatedAt = createdAt;
+  const { name, description } = req.body;
+  await db.run(
+    'INSERT INTO projects (id, name, description, createdAt, updatedAt) VALUES (?,?,?,?,?)',
+    id,
+    name,
+    description,
+    createdAt,
+    updatedAt
+  );
+  const project = await db.get('SELECT * FROM projects WHERE id=?', id);
+  res.json(project);
+});
+
+app.put('/api/projects/:id', async (req, res) => {
+  const id = req.params.id;
+  const updatedAt = new Date().toISOString();
+  const { name, description } = req.body;
+  await db.run(
+    'UPDATE projects SET name=?, description=?, updatedAt=? WHERE id=?',
+    name,
+    description,
+    updatedAt,
+    id
+  );
+  const project = await db.get('SELECT * FROM projects WHERE id=?', id);
+  res.json(project);
+});
+
+app.delete('/api/projects/:id', async (req, res) => {
+  const id = req.params.id;
+  await db.run('DELETE FROM projects WHERE id=?', id);
+  await db.run('DELETE FROM screens WHERE projectId=?', id);
+  await db.run('DELETE FROM tags WHERE projectId=?', id);
+  const scripts = await db.all('SELECT id FROM testScripts WHERE projectId=?', id);
+  for (const s of scripts) {
+    await db.run('DELETE FROM testResults WHERE testScriptId=?', s.id);
+  }
+  await db.run('DELETE FROM testScripts WHERE projectId=?', id);
+  res.json({ success: true });
+});
+
+// Screens
+app.get('/api/screens', async (_req, res) => {
+  const rows = await db.all('SELECT * FROM screens');
+  res.json(rows);
+});
+
+app.post('/api/screens', async (req, res) => {
+  const id = generateId();
+  const createdAt = new Date().toISOString();
+  const updatedAt = createdAt;
+  const { name, domain, urlPath, projectId, description } = req.body;
+  await db.run(
+    'INSERT INTO screens (id,name,domain,urlPath,projectId,description,createdAt,updatedAt) VALUES (?,?,?,?,?,?,?,?)',
+    id,
+    name,
+    domain,
+    urlPath,
+    projectId,
+    description,
+    createdAt,
+    updatedAt
+  );
+  const screen = await db.get('SELECT * FROM screens WHERE id=?', id);
+  res.json(screen);
+});
+
+app.put('/api/screens/:id', async (req, res) => {
+  const id = req.params.id;
+  const updatedAt = new Date().toISOString();
+  const { name, domain, urlPath, projectId, description } = req.body;
+  await db.run(
+    'UPDATE screens SET name=?, domain=?, urlPath=?, projectId=?, description=?, updatedAt=? WHERE id=?',
+    name,
+    domain,
+    urlPath,
+    projectId,
+    description,
+    updatedAt,
+    id
+  );
+  const screen = await db.get('SELECT * FROM screens WHERE id=?', id);
+  res.json(screen);
+});
+
+app.delete('/api/screens/:id', async (req, res) => {
+  const id = req.params.id;
+  await db.run('DELETE FROM screens WHERE id=?', id);
+  await db.run('DELETE FROM testScripts WHERE screenId=?', id);
+  res.json({ success: true });
+});
+
+// Tags
+app.get('/api/tags', async (_req, res) => {
+  const rows = await db.all('SELECT * FROM tags');
+  res.json(rows);
+});
+
+app.post('/api/tags', async (req, res) => {
+  const id = generateId();
+  const createdAt = new Date().toISOString();
+  const { name, projectId } = req.body;
+  await db.run('INSERT INTO tags (id,name,projectId,createdAt) VALUES (?,?,?,?)', id, name, projectId, createdAt);
+  const tag = await db.get('SELECT * FROM tags WHERE id=?', id);
+  res.json(tag);
+});
+
+app.delete('/api/tags/:id', async (req, res) => {
+  const id = req.params.id;
+  await db.run('DELETE FROM tags WHERE id=?', id);
+  res.json({ success: true });
+});
+
+// Test Scripts
+app.get('/api/test-scripts', async (_req, res) => {
+  const rows = await db.all('SELECT * FROM testScripts');
+  res.json(rows);
+});
+
+app.post('/api/test-scripts', async (req, res) => {
+  const id = generateId();
+  const createdAt = new Date().toISOString();
+  const updatedAt = createdAt;
+  const { name, projectId, screenId, tagId, fileName, fileContent } = req.body;
+  const version = 1;
+  await db.run(
+    'INSERT INTO testScripts (id,name,projectId,screenId,tagId,version,fileName,fileContent,createdAt,updatedAt) VALUES (?,?,?,?,?,?,?,?,?,?)',
+    id,
+    name,
+    projectId,
+    screenId,
+    tagId,
+    version,
+    fileName,
+    fileContent,
+    createdAt,
+    updatedAt
+  );
+  const script = await db.get('SELECT * FROM testScripts WHERE id=?', id);
+  res.json(script);
+});
+
+app.put('/api/test-scripts/:id', async (req, res) => {
+  const id = req.params.id;
+  const existing = await db.get('SELECT * FROM testScripts WHERE id=?', id);
+  if (!existing) return res.status(404).end();
+  const updatedAt = new Date().toISOString();
+  const version = (existing.version || 1) + 1;
+  const { name, projectId, screenId, tagId, fileName, fileContent } = req.body;
+  await db.run(
+    'UPDATE testScripts SET name=?, projectId=?, screenId=?, tagId=?, version=?, fileName=?, fileContent=?, updatedAt=? WHERE id=?',
+    name,
+    projectId,
+    screenId,
+    tagId,
+    version,
+    fileName,
+    fileContent,
+    updatedAt,
+    id
+  );
+  const script = await db.get('SELECT * FROM testScripts WHERE id=?', id);
+  res.json(script);
+});
+
+app.delete('/api/test-scripts/:id', async (req, res) => {
+  const id = req.params.id;
+  await db.run('DELETE FROM testScripts WHERE id=?', id);
+  await db.run('DELETE FROM testResults WHERE testScriptId=?', id);
+  res.json({ success: true });
+});
+
+// Test Results
+function parseResult(row) {
+  if (!row) return row;
+  return {
+    ...row,
+    screenshots: row.screenshots ? JSON.parse(row.screenshots) : [],
+    consoleErrors: row.consoleErrors ? JSON.parse(row.consoleErrors) : [],
+    steps: row.steps ? JSON.parse(row.steps) : []
+  };
+}
+
+app.get('/api/test-results', async (_req, res) => {
+  const rows = await db.all('SELECT * FROM testResults');
+  res.json(rows.map(parseResult));
+});
+
+app.post('/api/test-results', async (req, res) => {
+  const id = generateId();
+  const createdAt = new Date().toISOString();
+  const {
+    testScriptId,
+    status,
+    startTime,
+    endTime,
+    errorMessage,
+    screenshots = [],
+    consoleErrors = [],
+    steps = []
+  } = req.body;
+  await db.run(
+    'INSERT INTO testResults (id,testScriptId,status,startTime,endTime,errorMessage,screenshots,consoleErrors,steps,createdAt) VALUES (?,?,?,?,?,?,?,?,?,?)',
+    id,
+    testScriptId,
+    status,
+    startTime,
+    endTime,
+    errorMessage,
+    JSON.stringify(screenshots),
+    JSON.stringify(consoleErrors),
+    JSON.stringify(steps),
+    createdAt
+  );
+  const result = await db.get('SELECT * FROM testResults WHERE id=?', id);
+  res.json(parseResult(result));
+});
+
+app.delete('/api/test-results/:id', async (req, res) => {
+  const id = req.params.id;
+  await db.run('DELETE FROM testResults WHERE id=?', id);
+  res.json({ success: true });
+});
+
+// Initialize sample data
+app.post('/api/init', async (_req, res) => {
+  const count = await db.get('SELECT COUNT(*) as c FROM projects');
+  if (count.c > 0) return res.json({ success: true });
+
+  // Sample projects
+  const now = new Date().toISOString();
+  const project1Id = generateId();
+  await db.run('INSERT INTO projects (id,name,description,createdAt,updatedAt) VALUES (?,?,?,?,?)', project1Id, 'E-commerce Website', 'Main e-commerce platform testing', now, now);
+  const project2Id = generateId();
+  await db.run('INSERT INTO projects (id,name,description,createdAt,updatedAt) VALUES (?,?,?,?,?)', project2Id, 'Admin Dashboard', 'Backend admin panel testing', now, now);
+
+  // Screens
+  const s1id = generateId();
+  await db.run('INSERT INTO screens (id,name,domain,urlPath,projectId,description,createdAt,updatedAt) VALUES (?,?,?,?,?,?,?,?)', s1id, 'Login Page', 'https://example-store.com', '/login', project1Id, 'User authentication screen', now, now);
+  const s2id = generateId();
+  await db.run('INSERT INTO screens (id,name,domain,urlPath,projectId,description,createdAt,updatedAt) VALUES (?,?,?,?,?,?,?,?)', s2id, 'Product List', 'https://example-store.com', '/products', project1Id, 'Product listing and search', now, now);
+
+  // Tags
+  const tag1id = generateId();
+  await db.run('INSERT INTO tags (id,name,projectId,createdAt) VALUES (?,?,?,?)', tag1id, 'regression', project1Id, now);
+  const tag2id = generateId();
+  await db.run('INSERT INTO tags (id,name,projectId,createdAt) VALUES (?,?,?,?)', tag2id, 'smoke', project1Id, now);
+
+  // Test script
+  const scriptId = generateId();
+  await db.run('INSERT INTO testScripts (id,name,projectId,screenId,tagId,version,fileName,fileContent,createdAt,updatedAt) VALUES (?,?,?,?,?,?,?,?,?,?)', scriptId, 'Login Flow Test', project1Id, s1id, tag1id, 1, 'login-test.js', `const puppeteer = require('puppeteer');\n\n(async () => {\n  const browser = await puppeteer.launch();\n  const page = await browser.newPage();\n\n  await page.goto('https://example-store.com/login');\n  await page.type('#email', 'test@example.com');\n  await page.type('#password', 'password123');\n  await page.click('#login-button');\n\n  await browser.close();\n})();`, now, now);
+
+  // Test result
+  const resultId = generateId();
+  await db.run('INSERT INTO testResults (id,testScriptId,status,startTime,endTime,screenshots,consoleErrors,steps,createdAt) VALUES (?,?,?,?,?,?,?,?,?)', resultId, scriptId, 'success', new Date(Date.now() - 300000).toISOString(), new Date(Date.now() - 290000).toISOString(), '[]', '[]', JSON.stringify([{ id: generateId(), stepNumber: 1, url: 'https://example-store.com/login', consoleErrors: [], timestamp: new Date(Date.now() - 295000).toISOString() }]), now);
+
+  res.json({ success: true });
+});
+
+const PORT = 3001;
+initDb().then(() => {
+  app.listen(PORT, () => {
+    console.log(`API server running on port ${PORT}`);
+  });
+});
+

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -4,10 +4,9 @@ import {
   LayoutDashboard, 
   FolderOpen, 
   Monitor, 
-  FileCode, 
-  Tag, 
-  BarChart3, 
-  Settings,
+  FileCode,
+  Tag,
+  BarChart3,
   PlayCircle
 } from 'lucide-react';
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BarChart3, FolderOpen, Monitor, FileCode, Tag, CheckCircle, XCircle, Clock } from 'lucide-react';
+import { BarChart3, FolderOpen, Monitor, FileCode, CheckCircle, XCircle, Clock } from 'lucide-react';
 import { TestAutomationAPI } from '../utils/api';
 
 const Dashboard: React.FC = () => {

--- a/src/pages/TestResults.tsx
+++ b/src/pages/TestResults.tsx
@@ -28,10 +28,6 @@ const TestResults: React.FC = () => {
     const script = getScript(result.testScriptId);
     if (!script) return false;
 
-    const project = getProject(script.projectId);
-    const screen = getScreen(script.screenId);
-    const tag = getTag(script.tagId);
-
     const matchesSearch = script.name.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesProject = !filterProject || script.projectId === filterProject;
     const matchesScreen = !filterScreen || script.screenId === filterScreen;
@@ -309,7 +305,7 @@ const TestResults: React.FC = () => {
             <div>
               <h3 className="text-lg font-semibold text-slate-900 mb-3">Test Steps</h3>
               <div className="space-y-4">
-                {viewingResult.steps.map((step, index) => (
+                {viewingResult.steps.map((step) => (
                   <div key={step.id} className="border border-slate-200 p-4 rounded-lg">
                     <div className="flex items-center justify-between mb-2">
                       <h4 className="font-medium text-slate-900">Step {step.stepNumber}</h4>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,308 +1,114 @@
 import { Project, Screen, Tag, TestScript, TestResult, ApiKeyData } from '../types';
 
-const API_KEY = 'test-automation-key-2025';
+const API_URL = 'http://localhost:3001/api';
 
-// Simulated API with localStorage
+// Helper for synchronous HTTP requests
+function request<T>(method: string, path: string, body?: unknown): T {
+  const xhr = new XMLHttpRequest();
+  xhr.open(method, `${API_URL}${path}`, false);
+  xhr.setRequestHeader('Content-Type', 'application/json');
+  xhr.send(body ? JSON.stringify(body) : null);
+  if (xhr.status >= 200 && xhr.status < 300) {
+    return xhr.responseText ? JSON.parse(xhr.responseText) : (undefined as unknown as T);
+  }
+  throw new Error(xhr.statusText);
+}
+
 export class TestAutomationAPI {
-  private static getStorageKey(entity: string): string {
-    return `test-automation-${entity}`;
-  }
-
-  private static generateId(): string {
-    return Date.now().toString(36) + Math.random().toString(36).substr(2);
-  }
-
-  // API Key validation
   static validateApiKey(key: string): ApiKeyData {
-    return {
-      key: API_KEY,
-      isValid: key === API_KEY
-    };
+    const API_KEY = 'test-automation-key-2025';
+    return { key: API_KEY, isValid: key === API_KEY };
   }
 
   static getApiKey(): string {
-    return API_KEY;
+    return 'test-automation-key-2025';
   }
 
   // Projects
   static getProjects(): Project[] {
-    const data = localStorage.getItem(this.getStorageKey('projects'));
-    return data ? JSON.parse(data) : [];
+    return request<Project[]>('GET', '/projects');
   }
 
   static createProject(project: Omit<Project, 'id' | 'createdAt' | 'updatedAt'>): Project {
-    const projects = this.getProjects();
-    const newProject: Project = {
-      ...project,
-      id: this.generateId(),
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
-    projects.push(newProject);
-    localStorage.setItem(this.getStorageKey('projects'), JSON.stringify(projects));
-    return newProject;
+    return request<Project>('POST', '/projects', project);
   }
 
-  static updateProject(id: string, updates: Partial<Project>): Project | null {
-    const projects = this.getProjects();
-    const index = projects.findIndex(p => p.id === id);
-    if (index === -1) return null;
-
-    projects[index] = {
-      ...projects[index],
-      ...updates,
-      updatedAt: new Date().toISOString()
-    };
-    localStorage.setItem(this.getStorageKey('projects'), JSON.stringify(projects));
-    return projects[index];
+  static updateProject(id: string, updates: Partial<Project>): Project {
+    return request<Project>('PUT', `/projects/${id}`, updates);
   }
 
   static deleteProject(id: string): boolean {
-    const projects = this.getProjects().filter(p => p.id !== id);
-    localStorage.setItem(this.getStorageKey('projects'), JSON.stringify(projects));
-    
-    // Also delete related data
-    const screens = this.getScreens().filter(s => s.projectId !== id);
-    localStorage.setItem(this.getStorageKey('screens'), JSON.stringify(screens));
-    
-    const tags = this.getTags().filter(t => t.projectId !== id);
-    localStorage.setItem(this.getStorageKey('tags'), JSON.stringify(tags));
-    
-    const scripts = this.getTestScripts().filter(s => s.projectId !== id);
-    localStorage.setItem(this.getStorageKey('testScripts'), JSON.stringify(scripts));
-    
+    request('DELETE', `/projects/${id}`);
     return true;
   }
 
   // Screens
   static getScreens(): Screen[] {
-    const data = localStorage.getItem(this.getStorageKey('screens'));
-    return data ? JSON.parse(data) : [];
+    return request<Screen[]>('GET', '/screens');
   }
 
   static createScreen(screen: Omit<Screen, 'id' | 'createdAt' | 'updatedAt'>): Screen {
-    const screens = this.getScreens();
-    const newScreen: Screen = {
-      ...screen,
-      id: this.generateId(),
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
-    screens.push(newScreen);
-    localStorage.setItem(this.getStorageKey('screens'), JSON.stringify(screens));
-    return newScreen;
+    return request<Screen>('POST', '/screens', screen);
   }
 
-  static updateScreen(id: string, updates: Partial<Screen>): Screen | null {
-    const screens = this.getScreens();
-    const index = screens.findIndex(s => s.id === id);
-    if (index === -1) return null;
-
-    screens[index] = {
-      ...screens[index],
-      ...updates,
-      updatedAt: new Date().toISOString()
-    };
-    localStorage.setItem(this.getStorageKey('screens'), JSON.stringify(screens));
-    return screens[index];
+  static updateScreen(id: string, updates: Partial<Screen>): Screen {
+    return request<Screen>('PUT', `/screens/${id}`, updates);
   }
 
   static deleteScreen(id: string): boolean {
-    const screens = this.getScreens().filter(s => s.id !== id);
-    localStorage.setItem(this.getStorageKey('screens'), JSON.stringify(screens));
-    
-    // Also delete related test scripts
-    const scripts = this.getTestScripts().filter(s => s.screenId !== id);
-    localStorage.setItem(this.getStorageKey('testScripts'), JSON.stringify(scripts));
-    
+    request('DELETE', `/screens/${id}`);
     return true;
   }
 
   // Tags
   static getTags(): Tag[] {
-    const data = localStorage.getItem(this.getStorageKey('tags'));
-    return data ? JSON.parse(data) : [];
+    return request<Tag[]>('GET', '/tags');
   }
 
   static createTag(tag: Omit<Tag, 'id' | 'createdAt'>): Tag {
-    const tags = this.getTags();
-    
-    // Check if tag already exists in project
-    const existingTag = tags.find(t => t.name === tag.name && t.projectId === tag.projectId);
-    if (existingTag) {
-      throw new Error('Tag already exists in this project');
-    }
-    
-    const newTag: Tag = {
-      ...tag,
-      id: this.generateId(),
-      createdAt: new Date().toISOString()
-    };
-    tags.push(newTag);
-    localStorage.setItem(this.getStorageKey('tags'), JSON.stringify(tags));
-    return newTag;
+    return request<Tag>('POST', '/tags', tag);
   }
 
   static deleteTag(id: string): boolean {
-    const tags = this.getTags().filter(t => t.id !== id);
-    localStorage.setItem(this.getStorageKey('tags'), JSON.stringify(tags));
+    request('DELETE', `/tags/${id}`);
     return true;
   }
 
   // Test Scripts
   static getTestScripts(): TestScript[] {
-    const data = localStorage.getItem(this.getStorageKey('testScripts'));
-    return data ? JSON.parse(data) : [];
+    return request<TestScript[]>('GET', '/test-scripts');
   }
 
   static createTestScript(script: Omit<TestScript, 'id' | 'version' | 'createdAt' | 'updatedAt'>): TestScript {
-    const scripts = this.getTestScripts();
-    
-    // Auto-increment version
-    const existingVersions = scripts
-      .filter(s => s.name === script.name && s.projectId === script.projectId && s.screenId === script.screenId)
-      .map(s => s.version);
-    
-    const nextVersion = existingVersions.length > 0 ? Math.max(...existingVersions) + 1 : 1;
-    
-    const newScript: TestScript = {
-      ...script,
-      id: this.generateId(),
-      version: nextVersion,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
-    scripts.push(newScript);
-    localStorage.setItem(this.getStorageKey('testScripts'), JSON.stringify(scripts));
-    return newScript;
+    return request<TestScript>('POST', '/test-scripts', script);
   }
 
-  static updateTestScript(id: string, updates: Partial<TestScript>): TestScript | null {
-    const scripts = this.getTestScripts();
-    const index = scripts.findIndex(s => s.id === id);
-    if (index === -1) return null;
-
-    scripts[index] = {
-      ...scripts[index],
-      ...updates,
-      updatedAt: new Date().toISOString()
-    };
-    localStorage.setItem(this.getStorageKey('testScripts'), JSON.stringify(scripts));
-    return scripts[index];
+  static updateTestScript(id: string, updates: Partial<TestScript>): TestScript {
+    return request<TestScript>('PUT', `/test-scripts/${id}`, updates);
   }
 
   static deleteTestScript(id: string): boolean {
-    const scripts = this.getTestScripts().filter(s => s.id !== id);
-    localStorage.setItem(this.getStorageKey('testScripts'), JSON.stringify(scripts));
+    request('DELETE', `/test-scripts/${id}`);
     return true;
   }
 
   // Test Results
   static getTestResults(): TestResult[] {
-    const data = localStorage.getItem(this.getStorageKey('testResults'));
-    return data ? JSON.parse(data) : [];
+    return request<TestResult[]>('GET', '/test-results');
   }
 
   static createTestResult(result: Omit<TestResult, 'id' | 'createdAt'>): TestResult {
-    const results = this.getTestResults();
-    const newResult: TestResult = {
-      ...result,
-      id: this.generateId(),
-      createdAt: new Date().toISOString()
-    };
-    results.push(newResult);
-    localStorage.setItem(this.getStorageKey('testResults'), JSON.stringify(results));
-    return newResult;
+    return request<TestResult>('POST', '/test-results', result);
   }
 
   static deleteTestResult(id: string): boolean {
-    const results = this.getTestResults().filter(r => r.id !== id);
-    localStorage.setItem(this.getStorageKey('testResults'), JSON.stringify(results));
+    request('DELETE', `/test-results/${id}`);
     return true;
   }
 
-  // Initialize with sample data
-  static initializeSampleData() {
-    if (localStorage.getItem(this.getStorageKey('projects'))) return;
-
-    // Sample projects
-    const project1 = this.createProject({
-      name: 'E-commerce Website',
-      description: 'Main e-commerce platform testing'
-    });
-
-    const project2 = this.createProject({
-      name: 'Admin Dashboard',
-      description: 'Backend admin panel testing'
-    });
-
-    // Sample screens
-    const screen1 = this.createScreen({
-      name: 'Login Page',
-      domain: 'https://example-store.com',
-      urlPath: '/login',
-      projectId: project1.id,
-      description: 'User authentication screen'
-    });
-
-    const screen2 = this.createScreen({
-      name: 'Product List',
-      domain: 'https://example-store.com',
-      urlPath: '/products',
-      projectId: project1.id,
-      description: 'Product listing and search'
-    });
-
-    // Sample tags
-    const tag1 = this.createTag({
-      name: 'regression',
-      projectId: project1.id
-    });
-
-    const tag2 = this.createTag({
-      name: 'smoke',
-      projectId: project1.id
-    });
-
-    // Sample test scripts
-    this.createTestScript({
-      name: 'Login Flow Test',
-      projectId: project1.id,
-      screenId: screen1.id,
-      tagId: tag1.id,
-      fileName: 'login-test.js',
-      fileContent: `const puppeteer = require('puppeteer');
-
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  
-  await page.goto('https://example-store.com/login');
-  await page.type('#email', 'test@example.com');
-  await page.type('#password', 'password123');
-  await page.click('#login-button');
-  
-  await browser.close();
-})();`
-    });
-
-    // Sample test results
-    this.createTestResult({
-      testScriptId: this.getTestScripts()[0].id,
-      status: 'success',
-      startTime: new Date(Date.now() - 300000).toISOString(),
-      endTime: new Date(Date.now() - 290000).toISOString(),
-      screenshots: [],
-      consoleErrors: [],
-      steps: [
-        {
-          id: this.generateId(),
-          stepNumber: 1,
-          url: 'https://example-store.com/login',
-          consoleErrors: [],
-          timestamp: new Date(Date.now() - 295000).toISOString()
-        }
-      ]
-    });
+  // Sample data initialization
+  static initializeSampleData(): void {
+    request('POST', '/init');
   }
 }
+


### PR DESCRIPTION
## Summary
- replace localStorage mock API with HTTP calls to a new Express + SQLite backend
- add Node server providing CRUD endpoints and sample data
- clean up unused imports to satisfy lint rules

## Testing
- `npm run lint`
- `npm install` *(fails: 403 Forbidden retrieving cors package)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a938561c83318c2851a54a0d0bd8